### PR TITLE
Use HTTPS URL for WW3 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "sorc/WW3"]
 	path = sorc/WW3
-	url = git@github.com:NOAA-EMC/WW3.git
+	url = https://github.com/NOAA-EMC/WW3.git
 	branch = prod/GLWUv2


### PR DESCRIPTION
This PR updates the RWPS WW3 submodule URLs from SSH to HTTPS to simplify repository setup and improve accessibility across development and HPC environments. Using HTTPS removes the requirement for GitHub SSH key configuration and allows users to initialize and update submodules without additional authentication setup for public repositories.

Test:
git clone https://github.com/NOAA-EMC/RWPS.git rwps
cd rwps
git submodule update --init --recursive