### PR TITLE
updated switch filename in sorc/build_ww3.sh

### DIFF
--- a/sorc/build_ww3.sh
+++ b/sorc/build_ww3.sh
@@ -46,7 +46,7 @@ module load build_ww3.${MACHINE_ID}
 module list 
 set -x 
 
-ww3switch=model/bin/switch_NCEP_rwps
+ww3switch=model/bin/switch_NWS_rwps
 
 # Check final exec folder exists
 finalexecdir=${HOMErwps}/exec


### PR DESCRIPTION
updated switch filename in sorc/build_ww3.sh to reflect name change in WW3 name from w3switch=model/bin/switch_NCEP_rwps to w3switch=model/bin/switch_NWS_rwps